### PR TITLE
fix(cpp): fix cpp language integer suffix

### DIFF
--- a/src/cpp/cpp.ts
+++ b/src/cpp/cpp.ts
@@ -273,7 +273,7 @@ export const language = <languages.IMonarchLanguage>{
 	// we include these common regular expressions
 	symbols: /[=><!~?:&|+\-*\/\^%]+/,
 	escapes: /\\(?:[abfnrtv\\"']|x[0-9A-Fa-f]{1,4}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8})/,
-	integersuffix: /(ll|LL|u|U|l|L)?(ll|LL|u|U|l|L)?/,
+	integersuffix: /((l|L|ll|LL)?(u|U)?)|((u|U)?(l|L|ll|LL)?)/,
 	floatsuffix: /[fFlL]?/,
 	encoding: /u|u8|U|L/,
 


### PR DESCRIPTION
the old config `/(ll|LL|u|U|l|L)?(ll|LL|u|U|l|L)?/` also match some wrong suffix: `lll`, `llLL`, `LLl` and so on.